### PR TITLE
Disable contest ranking live updating for external users

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -739,6 +739,8 @@ class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
         context['users'] = users
         context['problems'] = problems
         context['last_msg'] = event.last()
+        if not self.request.user.is_authenticated or self.request.profile.is_external_user:
+            context['last_msg'] = None
         context['tab'] = self.tab
         return context
 


### PR DESCRIPTION
This will prevent us from DDoSing ourself during Moose competitions. If we deem the site is stable enough to handle the load afterwards, this commit can be reverted.